### PR TITLE
Implemented custom week. Added button actions. Removed rogue console.…

### DIFF
--- a/config/calendar/calendarRESTFunctions.js
+++ b/config/calendar/calendarRESTFunctions.js
@@ -9,44 +9,74 @@ var serviceAccount = require.main.require('./config/calendar/serviceAccount.json
 var calendarService = require.main.require('./config/calendar/calendarService.json');
 var calendarEvent = require.main.require('./config/calendar/calendarEvent.json');
 
-
+/**
+ * Initializes authenticated service account.
+ */
 var auth = new googleAuth();
 var oauth2Client = new auth.OAuth2();
 var calendar = googleapis.calendar('v3');
 var jwt = gcs.authorizeOAuth2Client(gcs.getServiceAccountJWT(serviceAccount.client_email, serviceAccount.private_key), oauth2Client);
 
-exports.insertCalendarEvent = function (summary, ssid, location, startDateTime, endDateTime) {
+/**
+ * Overwrites properties of the local JSON event template with the supplied arguments.
+ * @param {String} summary - The event summary.
+ * @param {String} ssid - The summer-school-id
+ * @param {String} location - An address for the event.
+ * @param {String} startDateTime - An ISO-8601 formatted dateTime string.
+ * @param {String} endDateTime - An ISO-8601 formatted dateTime string.
+ */
+function configureEvent (summary, ssid, location, startDateTime, endDateTime) {
     calendarEvent['summary'] = summary;
     calendarEvent['extendedProperties'].shared.ssid = ssid;
     calendarEvent['location'] = location;
     calendarEvent['start'].dateTime = startDateTime;
     calendarEvent['end'].dateTime = endDateTime;
+}
+
+/**
+ * Performs a call to googleCalendarService module to insert an event. Re-authenticates recursively if access-token rejected.
+ * Returns an event object if successful; else null.
+ * @param {String} summary - The event summary.
+ * @param {String} ssid - The summer-school-id
+ * @param {String} location - An address for the event.
+ * @param {String} startDateTime - An ISO-8601 formatted dateTime string.
+ * @param {String} endDateTime - An ISO-8601 formatted dateTime string.
+ */
+exports.insertCalendarEvent = function (summary, ssid, location, startDateTime, endDateTime) {
+    configureEvent(summary, ssid, location, startDateTime, endDateTime);
     gcs.insertCalendarEvent(calendarEvent, calendar, calendarService.calendar_id, oauth2Client, function(err, event) {
         if (err) {
-            console.log('The API said: ' + err);
-            console.log('error code: ' + err.code);
+            console.error('calendarRESTFunctions.js (insertCalendarEvent): The Google API returned code ' + err.code + ' for error: ' + err);
             if (gcs.isExpiredTokenError(err)) {
                 gcs.didReauthorizeOAuth2Client(jwt, oauth2Client, function(){
-                    console.log('Reauthorized, trying again...');
                     exports.insertCalendarEvent(summary, ssid, location, startDateTime, endDateTime); /* WARNING: Potential infinite loop */
                 });
+            } else {
+                return null;
             }
         } else {
-            console.log('Event ' + summary + ' inserted');
+            console.log('calendarRESTFunctions: Inserted event: ' + summary + ' successfully.');
             return event;
         }
     });
 }
 
+/**
+ * Performs a call to googleCalendarService module to fetch events between the provided dates. Re-authenticates recursively if access-token rejected.
+ * Returns a raw array of JSON encoded events if successful. Else returns an empty array.
+ * @param {String} startDateTime - An ISO-8601 formatted dateTime string.
+ * @param {String} endDateTime - An ISO-8601 formatted dateTime string.
+ */
 exports.listCalendarEvents = function (startDateTime, endDateTime, callback) {
     gcs.listCalendarEvents(calendar, calendarService.calendar_id, oauth2Client, startDateTime, endDateTime, function(err, data) {
         if (err) {
-            console.log('The API said: ' + err);
+            console.error('calendarRESTFunctions.js (listCalendarEvents): The Google API returned code ' + err.code + ' for error: ' + err);
             if (gcs.isExpiredTokenError(err)) {
                 gcs.didReauthorizeOAuth2Client(jwt, oauth2Client, function(){
-                    console.log("Reauthorized, trying again...");
                     exports.listCalendarEvents(startDateTime, endDateTime); /* WARNING: Potential infinite loop */
                 });
+            } else {
+                return '[]';
             }
         } else {
             callback(data.items);
@@ -54,8 +84,15 @@ exports.listCalendarEvents = function (startDateTime, endDateTime, callback) {
     });
 }
 
+/**
+ * Performs a call to googleCalendarTools module to fetch events for a week (Defined as Saturday -> Saturday). Uses googleCalendarService module to perform
+ * request. Returns a custom JSON array of tuples containing a date and its corresponding array of events if successful. Else returns an array of dates without
+ * any events.
+ * @param {Integer} week - An integer representing the current week offset.
+ * @param {Function} callback - Callback function to execute upon completion.
+ */
 exports.listCalendarWeekEvents = function (week, callback) {
-    gct.getWeekEvents(week, exports.listCalendarEvents, function(data) {
+    gct.getExtendedWeekEvents(week, exports.listCalendarEvents, function(data) {
         callback(JSON.stringify(data));
     });
 }

--- a/config/calendar/googleCalendarTools.js
+++ b/config/calendar/googleCalendarTools.js
@@ -61,6 +61,19 @@ module.exports = function(gcs) {
     }
 
     /**
+     * Creates and returns a new Date instance containing the value of the last Saturday. If it is Saturday, the last Saturday was last Saturday.
+     * @param {Integer} offset - Optional offset in weeks. Supports both positive and negative values.
+     * @param {Boolean} midnight - Sets the time to midnight if true. Else morning
+     */
+    tools.getSaturday = function(offset = 0, midnight) {
+        var d = new Date();
+        var t = d.getDate() - (d.getDay() == 0 ? 6 : d.getDay() - 1) - 2;
+        (midnight ? d.setHours(23,59,59,999) : d.setHours(0,0,0,0));
+        d.setDate(t + offset * 7);
+        return d;
+    }
+
+    /**
      * Creates and returns a new Date instance containing the value of the next Sunday. If it is Sunday, the next Sunday is today.
      * @param {Integer} offset - Optional offset in weeks. Supports both positive and negative values.
      */
@@ -73,19 +86,19 @@ module.exports = function(gcs) {
     }
 
     /**
-     * Returns the events of a week separated by day. The result of this function is in form: [[Date,[Events]]]
-     * @param {Integer} offset - Optional offset in weeks. Supports both positive and negative values.
+     * Returns the events of a custom (startDay -> endDay) week separated by day. The result of this function is in form: [[Date,[Events]]]
+     * @param {Date} startDay - The starting day of the week.
+     * @param {Date} endDay - The ending day of the week.
+     * @param {Integer} weekLength - The number of days in the week.
      * @param {Function} f - Function that will return the events for the supplied start and end date.
      * @param {Function} callback - The callback to be performed with the result.
      */
-    tools.getWeekEvents = function (offset = 0, f, callback) {
-        var start = tools.getMonday(offset);
-        var end = tools.getSunday(offset);
-        var weekDays = tools.getDays(start, 7);
-        var weekEvents = Array(7).fill().map(_ => []);
+    tools.getCustomWeekEvents = function(startDay, endDay, weekLength, f, callback) {
+        var weekDays = tools.getDays(startDay, weekLength);
+        var weekEvents = Array(weekLength).fill().map(_ => []);
         var result;
 
-        f (start.toISOString(), end.toISOString(), function(events) {
+        f (startDay.toISOString(), endDay.toISOString(), function(events) {
             var i, j;
             for (i = 0, j = 0; i < events.length; i++) {
                 var d = new Date(events[i].start.dateTime);
@@ -103,6 +116,26 @@ module.exports = function(gcs) {
                 return [x[0].toISOString(), x[1]];
             }));
         });
+    }
+
+    /**
+     * Returns the events of a week separated by day. The result of this function is in form: [[Date,[Events]]]
+     * @param {Integer} offset - Optional offset in weeks. Supports both positive and negative values.
+     * @param {Function} f - Function that will return the events for the supplied start and end date.
+     * @param {Function} callback - The callback to be performed with the result.
+     */
+    tools.getWeekEvents = function (offset = 0, f, callback) {
+        tools.getCustomWeekEvents(tools.getMonday(offset), tools.getSunday(offset), 7, f, callback);
+    }
+
+    /**
+     * Returns the events of a custom (Saturday -> Saturday) week. The result of this function is in form: [[Date,[Events]]]
+     * @param {Integer} offset - Optional offset in weeks. Supports both positive and negative values.
+     * @param {Function} f - Function that will return the events for the supplied start and end date.
+     * @param {Function} callback - The callback to be performed with the result.
+     */
+    tools.getExtendedWeekEvents = function (offset = 0, f, callback) {
+        tools.getCustomWeekEvents(tools.getSaturday(offset, false), tools.getSaturday(offset + 1, true), 8, f, callback);
     }
 
     return tools;

--- a/config/dayManipulation.js
+++ b/config/dayManipulation.js
@@ -2,12 +2,9 @@ var requireDir = require('require-dir');
 var json = require.main.require('./config/getJSON.js');
 
 exports.getWeekEvents = function(callback) {
-    var date = "NULL";
-    var week = 0;
     json.getJSON({
         type: 'GET',
-        path: '/calendar/event?startDate=' + date + '&endDate=' + date + "&week=" + week,
-        host: 'localhost',
+        path: '/calendar/event?week=' + 0,
         port: 8080,
         async: false,
         dataType: 'json'

--- a/config/getJSON.js
+++ b/config/getJSON.js
@@ -10,7 +10,6 @@ exports.getJSON = function(options, callback) {
     var prot = options.port == 443 ? https : http;
     var req = prot.request(options, function(res) {
         var output = '';
-        console.log(options.host + ':' + res.statusCode);
         res.setEncoding('utf8');
 
         res.on('data', function(chunk) {

--- a/controllers/API/calendar-event.js
+++ b/controllers/API/calendar-event.js
@@ -17,16 +17,20 @@ router.post('/calendar/event', function(request, response) {
 
 router.get('/calendar/event', function(request, response) {
     var params = request.query;
-    if (params.hasOwnProperty('startDate') && params.hasOwnProperty('endDate')) {
-        if (params.hasOwnProperty('week') && !isNaN(params.week)) {
-            calendarFunctions.listCalendarWeekEvents(parseInt(params.week), function(data) {
+    if (params.hasOwnProperty('week') && !isNaN(params.week)) {
+        calendarFunctions.listCalendarWeekEvents(parseInt(params.week), function(data) {
+            if (params.hasOwnProperty('rendered') && params.rendered == 'true') {
+                response.render('partials/schedule.ejs', {schedule: JSON.parse(data)});
+            } else {
                 response.send(data);
-            })
-        } else {
-            calendarFunctions.listCalendarEvents(params.startDate, params.endDate, function(data) {
-                response.send(data);
-            });
-        }
+            }
+        });
+    } else if (params.hasOwnProperty('startDate') && params.hasOwnProperty('endDate')) {
+        calendarFunctions.listCalendarEvents(params.startDate, params.endDate, function(data) {
+            response.send(data);
+        });
+    } else {
+        console.error('calendar-event.js: received an invalid get request\n');
     }
 });
 

--- a/views/loggedIn.ejs
+++ b/views/loggedIn.ejs
@@ -5,9 +5,9 @@
         <div id='wrap' class='full'>
             <% include partials/general_navigationbar.ejs %>
             <div class='row' id='event-screen'>
-                <% include partials/announcements %>
-                <% include partials/generalinfo %>
-                <% include partials/schedule %>
+                <span id='announcementsModule'> <% include partials/announcements %> </span>
+                <span id='generalinfoModule'> <% include partials/generalinfo %> </span>
+                <span id='scheduleModule'> <% include partials/schedule %> </span>
             </div>
 
             <% include partials/modal %>

--- a/views/partials/js/buttonHandler.js
+++ b/views/partials/js/buttonHandler.js
@@ -11,7 +11,7 @@
 		 	button.show();
 	 }
  }
- 
+
  function getButton(letter) {
 	 	switch(letter) {
 	 		case 'b':
@@ -30,11 +30,11 @@
  function isLowerCase(letter) {
 	 return letter == letter.toLowerCase();
  }
- 
+
  function isEmptyContainer(selector) {
 	 return !$(selector).val();
  }
- 
+
  function initialiseFinishButton() {
 	 getButton('f').click(function(event) {
          $type = $(this).data('type');
@@ -42,7 +42,7 @@
              if (isEmptyContainer(titleSelector)) { // no title, prevent the POST request
                  event.preventDefault();
                  alert("Please fill in a title and content");
-             } else if ($type == "edit") { 
+             } else if ($type == "edit") {
              	 // send a PUT request instead of POST if an existing item is edited.
                  event.preventDefault();
                  $.ajax({
@@ -58,13 +58,13 @@
          }
      });
  }
- 
+
  function initialiseBackButton() {
 	 getButton('b').click(function() {
          addNewItem($(modalSelector).data('type'), false);
      });
  }
- 
+
  function initialiseDeleteButton() {
 	 getButton('d').click(function() {
          if (confirm("Are you sure you want to delete?")) {
@@ -82,7 +82,7 @@
 
      });
  }
- 
+
  function initialiseEditButton() {
 	 getButton('e').click(function() {
          var editTitleValue = $(modalSelector + '.modal-title').text();
@@ -93,7 +93,7 @@
          $(descriptionSelector).val(editTextValue);
      });
  }
- 
+
  function initialisePreviewButton() {
 	 getButton('p').click(function() {
          $addType = $(modalSelector).data('show');
@@ -103,11 +103,10 @@
          }
      });
  }
- 
+
  function initialiseButtons() {
 	 initialiseFinishButton();
      initialiseBackButton();
      initialiseDeleteButton();
      initialiseEditButton();
-     initialisePreviewButton();
  }

--- a/views/partials/js/loggedIn.js
+++ b/views/partials/js/loggedIn.js
@@ -2,7 +2,7 @@
  	This script handles all UI manipulations for the modal. It dynamically changes
  	the input fields, buttons and texts of the modal depending on where is clicked.
   */
- 
+
  var titles = ["Add an announcement", "Add general information", "Add a new appointment"];
  var editTitles = ["Edit the announcement", "Edit general information"];
  var buttonTexts = ["Post announcement", "Add section", "Add appointment"];
@@ -13,9 +13,9 @@
  var modalSelector = '#add-announcement ';
  var titleSelector = '#announcementTitle ';
  var descriptionSelector = '#announcementDescription ';
- 
- 
- 
+
+
+
  function toggleShow(display) {
 	 if(display) {
 		 $(modalSelector + '.modal-add-body').hide();
@@ -25,10 +25,10 @@
 		 $(modalSelector + '.modal-show-body').hide();
 	 }
  }
- 
+
  function addNewItem(type, edit) {
      toggleButtons('bDeFP');
-     
+
      if (edit) {
          getButton('f').data('type', 'edit');
      } else {
@@ -58,22 +58,22 @@
      toggleShow(true);
      toggleButtons('bEfpd');
  };
- 
+
  function openTodaysSchedule() {
 	 $today = days[(((new Date().getDay()-1) % 7) + 7) % 7]; // take the positive modulo
  	 $('#' + $today).addClass('in');
  }
- 
+
  function initialiseScheduleDatePicker() {
 	 $( "#scheduleDate" ).datepicker({
 	     dateFormat: 'yy-mm-dd'
      });
  }
- 
+
  function emptyContainer(selector) {
 	 $(selector).val('');
  }
- 
+
  function initialiseModalOpeners() {
 	 $('.open-modal').click(function() {
          $(modalSelector).data('id', $(this).data('id'));
@@ -91,12 +91,13 @@
          }
      });
  }
- 
+
  $(function() {
  	 $('.img-thumbnail').hide();
  	 $('#thumbnailDiv').hide();
 	 openTodaysSchedule();
 	 initialiseScheduleDatePicker();
+     initialiseScheduleButtons();
 	 initialiseButtons();
 	 initialiseModalOpeners();
  });

--- a/views/partials/js/scheduleHandler.js
+++ b/views/partials/js/scheduleHandler.js
@@ -1,0 +1,28 @@
+
+/** The week offset: default is zero */
+var week = 0;
+
+function initialisePreviousButton() {
+    $('#sched-getprevious').on('click', function() {
+        week -= 1;
+        $.ajax({url: "/calendar/event?week=" + week + '&rendered=true', success: function (result) {
+            $('#scheduleModule').html(result);
+            initialiseScheduleButtons();
+        }});
+    });
+}
+
+function initialiseNextButton() {
+    $('#sched-getnext').on('click', function() {
+        week += 1;
+        $.ajax({url: "/calendar/event?week=" + week + '&rendered=true', success: function (result) {
+            $('#scheduleModule').html(result);
+            initialiseScheduleButtons();
+        }});
+    });
+}
+
+function initialiseScheduleButtons() {
+    initialisePreviousButton();
+    initialiseNextButton();
+}

--- a/views/partials/loggedin_header.ejs
+++ b/views/partials/loggedin_header.ejs
@@ -13,6 +13,7 @@
 
 <script>
 	<% include js/buttonHandler.js %>
+    <% include js/scheduleHandler.js %>
 	<% include js/loggedIn.js %>
 </script>
 

--- a/views/partials/schedule.ejs
+++ b/views/partials/schedule.ejs
@@ -3,14 +3,14 @@
         <h3 class='underline-title'><a href="../schedulepage">Schedule</a><span class="glyphicon glyphicon-plus pull-right open-modal" data-type=2 data-toggle="modal" data-target="#add-announcement" aria-hidden="true"></span></h3>
         <div class='row innerrow'>
             <ul class="list-group" id='sched-acc'>
-                <% var days = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]; %>
+                <% var days = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]; %>
                 <% var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]; %>
-                <% for(var i = 0; i < days.length; ++i) { %>
+                <% for(var i = 0; i < schedule.length; ++i) { %>
                 <%      var day = new Date(schedule[i][0]); %>
                 <%      var events = schedule[i][1];        %>
                     <li class="list-group-item" data-toggle="collapse" data-parent="#sched-acc" href="#<%= days[i] %>" aria-expanded="true" aria-controls="<%= days[i] %>">
                         <h5>
-                            <span> <%= days[i].charAt(0).toUpperCase() + days[i].slice(1) %>  </span>
+                            <span> <%= days[day.getDay()].charAt(0).toUpperCase() + days[day.getDay()].slice(1) %>  </span>
                             <span class="text-muted"> <%= ' (' +  months[day.getMonth()] + ' ' + day.getDate() + ')' %>  </span>
                         </h5>
                         <div id="<%= days[i] %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="<%= days[i] %>Schedule">
@@ -41,9 +41,11 @@
         </div>
         <div>
             <ul class="pager" style="padding-left:10px !important; padding-right:10px !important;">
-                <li class="previous"><a href="#">&larr; Last Week</a></li>
-                <li class="next"><a href="#">Next Week &rarr;</a></li>
+
+                <li class="previous"><button type="button" class="btn btn-primary btn-sm" id='sched-getprevious'>&larr; Last Week</button></li>
+                <li class="next"><button type="button" class="btn btn-primary btn-sm" id='sched-getnext'>Next Week &rarr;</button></li>
             </ul>
         </div>
+
     </div>
 </div>


### PR DESCRIPTION
**Changes**
1. Removed line responsible for logging: `undefined:200` from file `getJSON.js`
2. Changed calendar to present custom week (Saturday to next Saturday)
3. Implemented actions for buttons to change week events.

**Technical Details**

The buttons work by means of adding jQuery event listeners to the html elements of `schedule.ejs`. I added the file containing these functions (called `scheduleHandler.js`) to `partials/js` and initialized the event listeners by adding a line to the bottom of `loggedIn.js` next to the other initializers. When an event listener fires, a get request is dispatched to `calendar-event.js` with a query parameter indicating the events should be "rendered". The response is then an html rendition of `schedule.ejs` with the event data for the supplied week. The event listener then overwrites the calendar span tag html with the new html and re-attaches the event listeners to the buttons. 

**Edit:** 
I will have to resolve conflicts prior to merging. It seems the cache I added wasn't there despite fetching and branching from development earlier. I will likely omit it and add it back later.